### PR TITLE
Add back navigation and auto ID generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,8 +61,29 @@ def inference():
     patient_id = request.form["patient_id"]
     input_type = request.form["input_type"].lower()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    
-    case_dir = os.path.join(BASE_CASE_DIR, patient_id, f"case_{timestamp}")
+
+    patient_dir = os.path.join(BASE_CASE_DIR, patient_id)
+    os.makedirs(patient_dir, exist_ok=True)
+
+    info_path = os.path.join(patient_dir, "patient_info.json")
+    info = {}
+    if os.path.exists(info_path):
+        with open(info_path) as f:
+            info = json.load(f)
+
+    info.update({
+        "patient_id": patient_id,
+        "name": request.form.get("name", ""),
+        "age": request.form.get("age", ""),
+        "weight": request.form.get("weight", ""),
+        "sex": request.form.get("sex", ""),
+        "bg": request.form.get("bg", "")
+    })
+
+    with open(info_path, "w") as f:
+        json.dump(info, f, indent=2)
+
+    case_dir = os.path.join(patient_dir, f"case_{timestamp}")
     os.makedirs(case_dir, exist_ok=True)
 
     input_png_path = os.path.join(case_dir, "input.png")
@@ -293,6 +314,7 @@ def load_case(patient_id, timestamp):
     notes_path = os.path.join(case_dir, "notes.txt")
     annotations_path = os.path.join(case_dir, "annotations.json")
     index_path = os.path.join(BASE_CASE_DIR, patient_id, "index.json")
+    info_path = os.path.join(BASE_CASE_DIR, patient_id, "patient_info.json")
 
     doctor_id = ""
     if os.path.exists(index_path):
@@ -318,6 +340,10 @@ def load_case(patient_id, timestamp):
         "timestamp": timestamp,
         "doctor_id": doctor_id
     }
+
+    if os.path.exists(info_path):
+        with open(info_path) as f:
+            response["patient_info"] = json.load(f)
 
     if os.path.exists(notes_path):
         with open(notes_path) as f:

--- a/static/main.js
+++ b/static/main.js
@@ -7,6 +7,18 @@ const uploadControls = document.getElementById("uploadControls");
 const changeImageBtn = document.getElementById("changeImage");
 const removeImageBtn = document.getElementById("removeImage");
 
+const nextBtn = document.getElementById("nextBtn");
+const formCarousel = document.getElementById("formCarousel");
+const backBtn = document.getElementById("backBtn");
+
+const patientNameInput = document.getElementById("patientName");
+const ageInput = document.getElementById("age");
+const weightInput = document.getElementById("weight");
+const sexInput = document.getElementById("sex");
+const bgInput = document.getElementById("bg");
+const doctorIdInput = document.getElementById("doctorId");
+const patientIdInput = document.getElementById("patientId");
+
 let activeTimestamp = null;
 let activePatientId = null;
 let inputImg = null;
@@ -36,6 +48,16 @@ removeImageBtn.addEventListener("click", () => {
   imageInput.value = "";
   imagePreview.src = "/static/placeholder.png";
   uploadControls.classList.add("d-none");
+});
+
+nextBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  formCarousel.classList.add("show-upload");
+});
+
+backBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  formCarousel.classList.remove("show-upload");
 });
 
 function loadImage(src) {
@@ -213,7 +235,12 @@ document.getElementById("uploadForm").addEventListener("submit", async (e) => {
   e.preventDefault();
 
   const patientId = document.getElementById("patientId").value;
-  const doctorId = document.getElementById("doctorId").value || "UnknownDoctor";
+  const doctorId = doctorIdInput.value || "UnknownDoctor";
+  const patientName = patientNameInput.value || "";
+  const age = ageInput.value || "";
+  const weight = weightInput.value || "";
+  const sex = sexInput.value || "";
+  const bg = bgInput.value || "";
   const file = imageInput.files[0];
   if (!file || !patientId) return;
 
@@ -221,6 +248,11 @@ document.getElementById("uploadForm").addEventListener("submit", async (e) => {
   formData.append("image", file);
   formData.append("patient_id", patientId);
   formData.append("doctor_id", doctorId);
+  formData.append("name", patientName);
+  formData.append("age", age);
+  formData.append("weight", weight);
+  formData.append("sex", sex);
+  formData.append("bg", bg);
   const inputType = document.querySelector('input[name="inputType"]:checked').value;
   formData.append("input_type", inputType);
 
@@ -247,8 +279,13 @@ document.getElementById("uploadForm").addEventListener("submit", async (e) => {
   document.getElementById("exportBtn").classList.remove("d-none");
   document.getElementById("saveBtn").classList.remove("d-none");
   document.getElementById("patientInfo").classList.remove("d-none");
-  document.getElementById("uploadSection").classList.add("d-none");
+  formCarousel.classList.remove("show-upload");
+  document.getElementById("uploadForm").classList.add("d-none");
   document.getElementById("displayPatientId").textContent = patientId;
+  document.getElementById("displayPatientName").textContent = patientName;
+  document.getElementById("displayAge").textContent = age;
+  document.getElementById("displaySex").textContent = sex;
+  document.getElementById("displayBg").textContent = bg;
   document.getElementById("displayDoctorId").textContent = doctorId;
 
   inputImg = await loadImage("data:image/png;base64," + data.input_base64);
@@ -503,7 +540,14 @@ document.getElementById("saveBtn").addEventListener("click", async () => {
 });
 
 
-window.addEventListener("DOMContentLoaded", loadSidebarCases);
+window.addEventListener("DOMContentLoaded", () => {
+  patientIdInput.value = generatePatientId();
+  loadSidebarCases();
+});
+
+function generatePatientId() {
+  return Math.random().toString(36).substring(2, 8).toUpperCase();
+}
 
 async function loadSidebarCases() {
   const res = await fetch(`/api/all_cases`);
@@ -550,11 +594,15 @@ async function loadCase(patientId, timestamp) {
   document.getElementById("exportBtn").classList.remove("d-none");
   document.getElementById("patientInfo").classList.remove("d-none");
   document.getElementById("saveBtn").classList.remove("d-none");
-  document.getElementById("uploadSection").classList.add("d-none");
+  formCarousel.classList.remove("show-upload");
+  document.getElementById("uploadForm").classList.add("d-none");
   document.getElementById("displayPatientId").textContent = patientId;
+  document.getElementById("displayPatientName").textContent = data.patient_info?.name || "";
+  document.getElementById("displayAge").textContent = data.patient_info?.age || "";
+  document.getElementById("displaySex").textContent = data.patient_info?.sex || "";
+  document.getElementById("displayBg").textContent = data.patient_info?.bg || "";
   document.getElementById("displayDoctorId").textContent = data.doctor_id || "N/A";
 
-  console.log("Loaded case for patient %s at timestamp %s", patientId, timestamp, doctorId);
 
   const opacity1 = parseFloat(document.getElementById("opacity1").value);
   const opacity2 = parseFloat(document.getElementById("opacity2").value);

--- a/static/styles.css
+++ b/static/styles.css
@@ -282,6 +282,7 @@ body {
 .upload-form {
   max-width: 1000px;
   margin-top: 30px;
+  overflow: hidden;
 }
 
 .form-control-centered {
@@ -301,4 +302,24 @@ body {
   object-fit: contain;
   border: 1px solid #ccc;
   border-radius: 8px;
+}
+
+.main-content {
+  margin-left: 250px;
+  width: calc(100% - 250px);
+}
+
+.form-carousel {
+  display: flex;
+  width: 200%;
+  transition: transform 0.5s ease;
+}
+
+.form-carousel.show-upload {
+  transform: translateX(-50%);
+}
+
+.form-step {
+  width: 100%;
+  padding: 0 10px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,57 +33,86 @@
 
 
     <!-- Main Content -->
-    <div class="container pt-5 mt-5 glass-card flex-grow-1">
+    <div class="container pt-5 mt-5 glass-card flex-grow-1 main-content">
 
       <!-- Upload Section -->
-      <div id="uploadSection">
-        <form id="uploadForm" class="mx-auto upload-form text-center">
-          <div class="mb-3">
-            <label for="patientId" class="form-label">Patient ID</label>
-            <input type="text" class="form-control form-control-centered" id="patientId" required>
+      <form id="uploadForm" class="mx-auto upload-form text-center">
+        <div id="formCarousel" class="form-carousel">
+          <div class="form-step" id="detailsSection">
+            <div class="mb-3">
+              <label for="patientId" class="form-label">Patient ID</label>
+              <input type="text" class="form-control form-control-centered" id="patientId" readonly>
+            </div>
+            <div class="mb-3">
+              <label for="patientName" class="form-label">Patient Name</label>
+              <input type="text" class="form-control form-control-centered" id="patientName" required>
+            </div>
+            <div class="mb-3">
+              <label for="age" class="form-label">Age</label>
+              <input type="number" class="form-control form-control-centered" id="age" required>
+            </div>
+            <div class="mb-3">
+              <label for="weight" class="form-label">Weight</label>
+              <input type="text" class="form-control form-control-centered" id="weight">
+            </div>
+            <div class="mb-3">
+              <label for="sex" class="form-label">Sex</label>
+              <select id="sex" class="form-select form-control-centered">
+                <option value="Male">Male</option>
+                <option value="Female">Female</option>
+                <option value="Other">Other</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="bg" class="form-label">Blood Group</label>
+              <input type="text" class="form-control form-control-centered" id="bg">
+            </div>
+            <div class="mb-3">
+              <label for="doctorId" class="form-label">Doctor ID</label>
+              <input type="text" class="form-control form-control-centered" id="doctorId" required>
+            </div>
+            <button id="nextBtn" class="btn btn-primary mt-3">Next</button>
           </div>
-
-          <div class="mb-3">
-            <label for="doctorId" class="form-label">Doctor ID</label>
-            <input type="text" class="form-control form-control-centered" id="doctorId" required>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label">Input Type</label>
-            <div style="display: flex;">
-              <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="inputType" id="inputTypePng" value="png" checked>
-                <label class="form-check-label" for="inputTypePng">PNG</label>
-              </div>
-              <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="inputType" id="inputTypeDicom" value="dicom">
-                <label class="form-check-label" for="inputTypeDicom">DICOM</label>
+          <div class="form-step" id="uploadSection">
+            <div class="mb-3">
+              <label class="form-label">Input Type</label>
+              <div style="display: flex;">
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" name="inputType" id="inputTypePng" value="png" checked>
+                  <label class="form-check-label" for="inputTypePng">PNG</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" name="inputType" id="inputTypeDicom" value="dicom">
+                  <label class="form-check-label" for="inputTypeDicom">DICOM</label>
+                </div>
               </div>
             </div>
-          </div>
-
-          <div class="upload-frame mx-auto" id="uploadFrame">
-            <label for="imageInput" id="uploadLabel">
-              <img id="imagePreview" class="preview-image" src="{{ url_for('static', filename='placeholder.png') }}"
-                alt="Upload Image">
-            </label>
-            <input type="file" id="imageInput"  hidden>
-            <div id="uploadControls" class="d-none mt-2 d-flex justify-content-center gap-2">
-              <button type="button" class="btn btn-sm btn-secondary" id="changeImage">Change Image</button>
-              <button type="button" class="btn btn-sm btn-danger" id="removeImage">Remove Image</button>
+            <div class="upload-frame mx-auto" id="uploadFrame">
+              <label for="imageInput" id="uploadLabel">
+                <img id="imagePreview" class="preview-image" src="{{ url_for('static', filename='placeholder.png') }}"
+                  alt="Upload Image">
+              </label>
+              <input type="file" id="imageInput"  hidden>
+              <div id="uploadControls" class="d-none mt-2 d-flex justify-content-center gap-2">
+                <button type="button" class="btn btn-sm btn-secondary" id="changeImage">Change Image</button>
+                <button type="button" class="btn btn-sm btn-danger" id="removeImage">Remove Image</button>
+              </div>
             </div>
+            <button type="button" id="backBtn" class="btn btn-secondary mt-3 me-2">Back</button>
+            <button type="submit" class="btn btn-primary mt-3">Analyze</button>
           </div>
-
-          <button type="submit" class="btn btn-primary mt-3">Analyze</button>
-        </form>
-
-      </div>
+        </div>
+      </form>
 
       <!-- Patient Info -->
       <div id="patientInfo" class="d-none mt-2 mb-3">
         <div class="alert alert-info p-2">
-          <strong>Patient ID:</strong> <span id="displayPatientId"></span> &nbsp; | &nbsp;
-          <strong>Doctor ID:</strong> <span id="displayDoctorId"></span>
+          <strong>ID:</strong> <span id="displayPatientId"></span> &nbsp; | &nbsp;
+          <strong>Name:</strong> <span id="displayPatientName"></span> &nbsp; | &nbsp;
+          <strong>Age:</strong> <span id="displayAge"></span> &nbsp; | &nbsp;
+          <strong>Sex:</strong> <span id="displaySex"></span> &nbsp; | &nbsp;
+          <strong>BG:</strong> <span id="displayBg"></span> &nbsp; | &nbsp;
+          <strong>Doctor:</strong> <span id="displayDoctorId"></span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- auto-generate a patient id on page load
- hide overflow for sliding form and add back button
- hide upload form when viewing results
- fix sidebar overlap width

## Testing
- `python -m py_compile app.py`
- `python -m py_compile utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6858fce22b308329a13c6c8b37286882