### PR TITLE
Add doctor login and sharing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@
     ```
 - ALternatively, if just want to test, you can issue the following command: 
     `python app.py`
+
+When running for the first time, open `http://localhost:5000/login` and register a doctor account. Use this account to log in and access the analysis dashboard.

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, session, redirect, url_for
 import os
 import numpy as np
 import io
@@ -12,9 +12,24 @@ import json
 from fpdf import FPDF
 from flask import send_file
 from flask import render_template
+import sqlite3
+import hashlib
 
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
+app.secret_key = "change-this-key"
+DB_PATH = "doctors.db"
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS doctors (id TEXT PRIMARY KEY, name TEXT, password TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+init_db()
 UPLOAD_FOLDER = "uploads"
 BASE_CASE_DIR = "cases"
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
@@ -26,6 +41,13 @@ def after_request(response):
     response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
     response.headers.add('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS')
     return response
+
+@app.before_request
+def require_login():
+    if request.endpoint in {"login", "register", "static"} or request.endpoint is None:
+        return
+    if "doctor_id" not in session:
+        return redirect(url_for("login"))
 
 def tensor_to_base64(tensor):
     """Convert a PyTorch tensor to a base64 image string."""
@@ -150,7 +172,8 @@ def inference():
             "output2_base64": output2_base64,
             "input_base64": input_base64,
             "timestamp": timestamp,
-            "patient_info": info
+            "patient_info": info,
+            "doctor_id": session.get("doctor_id", "")
         })
 
     except Exception as e:
@@ -163,7 +186,7 @@ def export_analysis():
         data = request.get_json()
         patient_id = data["patient_id"]
         timestamp = data["timestamp"]
-        doctor_id = data["doctor_id"]
+        doctor_id = session.get("doctor_id", "")
         notes = data["notes"]
         annotations = data["annotations"]
         annotated_images = data["images"]
@@ -237,7 +260,7 @@ def save_analysis():
         data = request.get_json()
         patient_id = data["patient_id"]
         timestamp = data["timestamp"]
-        doctor_id = data["doctor_id"]
+        doctor_id = session.get("doctor_id", "")
         notes = data["notes"]
         annotations = data["annotations"]
         annotated_images = data["images"]
@@ -371,8 +394,52 @@ def load_case(patient_id, timestamp):
 
     return jsonify(response)
 
+
+@app.route("/api/search_doctors")
+def search_doctors():
+    q = request.args.get("q", "")
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT id, name FROM doctors WHERE id LIKE ? OR name LIKE ? LIMIT 10", (f"%{q}%", f"%{q}%"))
+    rows = cur.fetchall()
+    conn.close()
+    return jsonify([{"id": r[0], "name": r[1]} for r in rows])
+
+
+@app.route("/api/share", methods=["POST"])
+def share_case():
+    data = request.get_json()
+    patient_id = data.get("patient_id")
+    timestamp = data.get("timestamp")
+    target = data.get("doctor_id")
+    if not target:
+        return jsonify({"error": "doctor_id required"}), 400
+
+    index_path = os.path.join(BASE_CASE_DIR, patient_id, "index.json")
+    if not os.path.exists(index_path):
+        return jsonify({"error": "case not found"}), 404
+
+    with open(index_path) as f:
+        index_data = json.load(f)
+    found = False
+    for entry in index_data.get("cases", []):
+        if entry["timestamp"] == timestamp:
+            entry.setdefault("shared_with", [])
+            if target not in entry["shared_with"]:
+                entry["shared_with"].append(target)
+            found = True
+            break
+    if not found:
+        return jsonify({"error": "case not found"}), 404
+    with open(index_path, "w") as f:
+        json.dump(index_data, f, indent=2)
+    return jsonify({"message": "shared"})
+
 @app.route("/api/all_cases")
 def all_cases():
+    doctor_id = session.get("doctor_id")
+    if not doctor_id:
+        return jsonify({"cases": []})
     all_data = []
     for patient_id in os.listdir(BASE_CASE_DIR):
         patient_path = os.path.join(BASE_CASE_DIR, patient_id)
@@ -383,14 +450,58 @@ def all_cases():
             with open(index_path) as f:
                 index = json.load(f)
                 for case in index.get("cases", []):
-                    all_data.append({
-                        "patient_id": patient_id,
-                        "timestamp": case["timestamp"],
-                        "note": case.get("notes", "").split("\n")[0]  
-                    })
+                    if case.get("doctor_id") == doctor_id or doctor_id in case.get("shared_with", []):
+                        all_data.append({
+                            "patient_id": patient_id,
+                            "timestamp": case["timestamp"],
+                            "note": case.get("notes", "").split("\n")[0]
+                        })
         except Exception as e:
             print(f"Error reading index.json for {patient_id}: {e}")
     return jsonify({"cases": sorted(all_data, key=lambda x: x["timestamp"], reverse=True)})
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        doctor_id = request.form.get("doctor_id")
+        password = request.form.get("password", "")
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute("SELECT password, name FROM doctors WHERE id=?", (doctor_id,))
+        row = cur.fetchone()
+        conn.close()
+        if row and row[0] == hashlib.sha256(password.encode()).hexdigest():
+            session["doctor_id"] = doctor_id
+            session["doctor_name"] = row[1]
+            return redirect(url_for("home"))
+        return render_template("login.html", error="Invalid credentials")
+    return render_template("login.html")
+
+
+@app.route("/register", methods=["GET", "POST"])
+def register():
+    if request.method == "POST":
+        doctor_id = request.form.get("doctor_id")
+        name = request.form.get("name")
+        password = request.form.get("password", "")
+        hashed = hashlib.sha256(password.encode()).hexdigest()
+        try:
+            conn = sqlite3.connect(DB_PATH)
+            cur = conn.cursor()
+            cur.execute("INSERT INTO doctors (id, name, password) VALUES (?,?,?)", (doctor_id, name, hashed))
+            conn.commit()
+            conn.close()
+            return redirect(url_for("login"))
+        except sqlite3.IntegrityError:
+            return render_template("register.html", error="Doctor ID already exists")
+    return render_template("register.html")
+
+
+@app.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("login"))
 
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,10 +12,14 @@
 
 <body>
   <nav class="navbar fixed-top shadow-sm custom-navbar">
-    <div class="container-fluid justify-content-center">
-      <span class="navbar-brand mb-0 h4 text-center text-dark">
+    <div class="container-fluid justify-content-between">
+      <span class="navbar-brand mb-0 h4 text-dark">
         StenAnalysis
       </span>
+      <div class="d-flex align-items-center gap-3">
+        <span class="text-dark">Logged in as {{ session.get('doctor_id') }}</span>
+        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
+      </div>
     </div>
   </nav>
 
@@ -66,10 +70,6 @@
             <div class="mb-3">
               <label for="bg" class="form-label">Blood Group</label>
               <input type="text" class="form-control form-control-centered" id="bg">
-            </div>
-            <div class="mb-3">
-              <label for="doctorId" class="form-label">Doctor ID</label>
-              <input type="text" class="form-control form-control-centered" id="doctorId" required>
             </div>
             <button id="nextBtn" class="btn btn-primary mt-3">Next</button>
           </div>
@@ -187,6 +187,7 @@
       </div>
       <div class="d-grid mt-3">
         <button type="button" id="exportBtn" class="btn btn-outline-primary d-none">Export Analysis</button>
+        <button type="button" id="shareBtn" class="btn btn-outline-secondary d-none" data-bs-toggle="modal" data-bs-target="#shareModal">Share Analysis</button>
         <button type="button" id="saveBtn" class="btn btn-outline-success d-none">Save Analysis</button>
       </div>
 
@@ -213,8 +214,30 @@
         </div>
       </div>
     </div>
+
+    <!-- Share Modal -->
+    <div class="modal fade" id="shareModal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Share Analysis</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <label for="shareDoctor" class="form-label">Doctor</label>
+            <input type="text" id="shareDoctor" class="form-control" autocomplete="off">
+            <div id="doctorSuggestions" class="list-group mt-2"></div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <button type="button" id="shareConfirm" class="btn btn-primary">Share</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Doctor Login</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center" style="min-height: 100vh;">
+  <div class="glass-card p-4" style="max-width:400px; width:100%;">
+    <h4 class="text-center mb-3">Doctor Login</h4>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <label for="doctorId" class="form-label">Doctor ID</label>
+        <input type="text" class="form-control" id="doctorId" name="doctor_id" required>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Login</button>
+    </form>
+    <div class="mt-3 text-center">
+      <a href="{{ url_for('register') }}">Register</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Register Doctor</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center" style="min-height: 100vh;">
+  <div class="glass-card p-4" style="max-width:400px; width:100%;">
+    <h4 class="text-center mb-3">Register</h4>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <label for="doctorId" class="form-label">Doctor ID</label>
+        <input type="text" class="form-control" id="doctorId" name="doctor_id" required>
+      </div>
+      <div class="mb-3">
+        <label for="name" class="form-label">Name</label>
+        <input type="text" class="form-control" id="name" name="name" required>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Register</button>
+    </form>
+    <div class="mt-3 text-center">
+      <a href="{{ url_for('login') }}">Back to login</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement login, registration and session handling with SQLite
- display logged in doctor and logout link
- add share analysis workflow with modal and suggestions
- remove manual doctor ID field from analysis form
- filter sidebar by logged in doctor and shared cases

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a44efdfe8832985c140b3eef42c37